### PR TITLE
added the ebs checker script

### DIFF
--- a/AWS/EBSChecker/Dockerfile
+++ b/AWS/EBSChecker/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.9-slim-buster
+
+RUN pip3 install --upgrade boto3==1.16.8 botocore==1.19.8
+
+COPY ebs_checker.py /opt/ebs_checker.py
+
+ENTRYPOINT ["python3", "/opt/ebs_checker.py"]
+CMD ["--help"]

--- a/AWS/EBSChecker/README.MD
+++ b/AWS/EBSChecker/README.MD
@@ -1,0 +1,3 @@
+A script that checks the status of EBS volumes, and if it finds volumes in the Available status, it pushes the custom metric 'CustomMetric/EBSVolumes' to AWS CloudWatch, on the basis of which you can create an alert in Prometheus.
+Sometimes you need to make an exception, and this is implemented in this script.
+Just add the suffix "DONT_DELETE" to the Name tag of the corresponding EBS volume to skip such a volume.

--- a/AWS/EBSChecker/ebs_checker.py
+++ b/AWS/EBSChecker/ebs_checker.py
@@ -1,0 +1,63 @@
+import boto3
+import datetime
+import logging
+
+EBS_VOLUME_METRIC_NAME = 'CustomMetric/EBSVolumes'
+
+
+def get_available_ebs_volumes():
+    ec2 = boto3.client('ec2')
+
+    response = ec2.describe_volumes(
+        Filters=[{'Name': 'status', 'Values': ['available']}])
+    volumes = response['Volumes']
+
+    # Exclude the EBS volumes that contain the DONT_DELETE suffix in names
+    volumes_names = []
+    for volume in volumes:
+        volume_name = next((tag['Value'] for tag in volume.get(
+            'Tags', []) if tag['Key'] == 'Name'), None)
+        if volume_name and "DONT_DELETE" not in volume_name:
+            volumes_names.append(volume_name)
+    logging.warning(
+        "The following obsolete volumes were found: %s", volumes_names)
+
+    return volumes_names
+
+
+def push_custom_metric(volume_count):
+    cloudwatch = boto3.client('cloudwatch')
+
+    namespace = 'Custom/EBSVolumes'
+    unit = 'Count'
+
+    dimensions = [{'Name': 'MetricDimension', 'Value': 'EBSVolumes'}]
+
+    cloudwatch.put_metric_data(
+        MetricData=[
+            {
+                'MetricName': EBS_VOLUME_METRIC_NAME,
+                'Dimensions': dimensions,
+                'Timestamp': datetime.datetime.now(),
+                'Value': volume_count,
+                'Unit': unit
+            },
+        ],
+        Namespace=namespace
+    )
+
+
+def main():
+    volumes = get_available_ebs_volumes()
+    volume_count = len(volumes)
+    logging.warning("Found obsolete EBS volumes %s", volume_count)
+
+    if volume_count > 0:
+        push_custom_metric(volume_count)
+        logging.warning("Custom metric pushed to CloudWatch.")
+    else:
+        logging.info("EBS volumes in the Available state weren't found.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A script that checks the status of EBS volumes, and if it finds volumes in the Available status, it pushes the custom metric 'CustomMetric/EBSVolumes' to AWS CloudWatch, on the basis of which you can create an alert in Prometheus.
Sometimes you need to make an exception, and this is implemented in this script.
Just add the suffix "DONT_DELETE" to the Name tag of the corresponding EBS volume to skip such a volume.